### PR TITLE
Use Buffer.byteLength(data); to set request content length

### DIFF
--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -52,7 +52,7 @@ function httpsPost(options, callback) {
 
     var data = (typeof options.data !== 'string') ? JSON.stringify(options.data) : options.data;
 
-    options.headers['Content-Length'] = data.length;
+    options.headers['Content-Length'] = Buffer.byteLength(data);
 
     var req = https.request(options);
 
@@ -123,10 +123,10 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
         }
     };
 
-    if (config.sandboxEmailAddress) 
+    if (config.sandboxEmailAddress)
         options.headers['X-PAYPAL-SANDBOX-EMAIL-ADDRESS'] = config.sandboxEmailAddress;
-    
-    if (config.deviceIpAddress) 
+
+    if (config.deviceIpAddress)
         options.headers['X-PAYPAL-DEVICE-IPADDRESS'] = config.deviceIpAddress;
 
     httpsPost(options, function (error, response) {


### PR DESCRIPTION
Without this change PayPal throws an error when non-english characters like ö, ä, ß, Ü etc. are used within the request data.
