### PR TITLE
Only setEncoding if legal

### DIFF
--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -58,7 +58,10 @@ function httpsPost(options, callback) {
 
     req.on('response', function (res) {
         var response = '';
-        res.setEncoding('utf8');
+        //do not setEndcoding with browserify
+        if (res.setEncoding) {
+          res.setEncoding('utf8');
+        }
 
         res.on('data', function (chunk) {
             response += chunk;


### PR DESCRIPTION
`setEncoding` might not be available in browserified environments. Using it will break those environments.