### PR TITLE
set https port

### DIFF
--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -111,6 +111,7 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
 
     var options = {
         hostname:   config.sandbox ? config.sandboxHostname : config.productionHostname,
+        port:       443,
         path:       '/' + apiMethod,
         data:       data,
         headers: {


### PR DESCRIPTION
In conjunction with some setups (e.g. serving developing build on localhost with specific port), the `port` option will already be set. Thus, `httpsPost` will use this port and the request will fail.