### PR TITLE
set withCredentials: false

### DIFF
--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -49,6 +49,7 @@ function defaultPayload() {
 function httpsPost(options, callback) {
     options.method = 'POST';
     options.headers = options.headers || {};
+    options.withCredentials = false;
 
     var data = (typeof options.data !== 'string') ? JSON.stringify(options.data) : options.data;
 


### PR DESCRIPTION
Doesn't work with `browserfiy`, because `http-browserify` sets it to true here: https://github.com/substack/http-browserify/blob/master/lib/request.js#18. Some configurations (e.g. serving from `localhost`) break with that setting and it's not needed.