### PR TITLE
Set subject header if configured

### DIFF
--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -133,6 +133,9 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
     if (config.deviceIpAddress)
         options.headers['X-PAYPAL-DEVICE-IPADDRESS'] = config.deviceIpAddress;
 
+    if (config.subject)
+        options.headers['X-PAYPAL-SECURITY-SUBJECT'] = config.subject;
+
     httpsPost(options, function (error, response) {
         if (error) { return callback(error); }
 


### PR DESCRIPTION
To be able to execute commands on behalf of third party you have to set X-PAYPAL-SECURITY-SUBJECT header.