### PR TITLE
Custom Error support and removed duplicate lines for method binding

### DIFF
--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -155,30 +155,27 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
 
         body.httpStatusCode = statusCode;
 
-        if(body.responseEnvelope.ack !== "Success" || body.responseEnvelope.ack !== "SuccessWithWarning"){
-
-            if(body.error){
-                var msg = "";
-
-                if(Array.isArray(body.error)){
-                    
-                    for(e of body.error){
-                        msg += e.message ? (e.message+". ") : "";
-                    }
-                }
-                else
-                    msg = "Unknown Error with Paypal Adaptive Payments";
-
-                body.error.message = msg;
-
-                return callback(msg);
-            }
-            else
-                return cb("Unknown Error with Paypal Adaptive Payments");
-
+        if(body.responseEnvelope.ack === "Success" || body.responseEnvelope.ack === "SuccessWithWarning"){
+            return callback(null, body);
         }
+        else{
 
-        callback(null, body);
+            var msg = "";
+
+            if(Array.isArray(body.error)){
+                
+                for(e of body.error){
+                    msg += e.message ? (e.message+". ") : "";
+                }
+
+                var err = new Error(msg);
+            }
+            else{
+                var err = new Error('Response ack is ' + body.responseEnvelope.ack + '. Check the response for more info');
+            }
+            
+            return callback(err, body);
+        }
     });
 };
 

--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -58,8 +58,11 @@ function httpsPost(options, callback) {
 
     req.on('response', function (res) {
         var response = '';
-        res.setEncoding('utf8');
 
+        //do not setEndcoding with browserify
+        if(res.setEncoding){
+            res.setEncoding('utf8');
+        }
         res.on('data', function (chunk) {
             response += chunk;
         });

--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -129,6 +129,9 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
     if (config.deviceIpAddress)
         options.headers['X-PAYPAL-DEVICE-IPADDRESS'] = config.deviceIpAddress;
 
+    if (config.subject)
+        options.headers['X-PAYPAL-SECURITY-SUBJECT'] = config.subject;
+
     httpsPost(options, function (error, response) {
         if (error) { return callback(error); }
 

--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -58,10 +58,7 @@ function httpsPost(options, callback) {
 
     req.on('response', function (res) {
         var response = '';
-        //do not setEndcoding with browserify
-        if (res.setEncoding) {
-          res.setEncoding('utf8');
-        }
+        res.setEncoding('utf8');
 
         res.on('data', function (chunk) {
             response += chunk;
@@ -114,7 +111,6 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
 
     var options = {
         hostname:   config.sandbox ? config.sandboxHostname : config.productionHostname,
-        port:       443,
         path:       '/' + apiMethod,
         data:       data,
         headers: {
@@ -133,11 +129,11 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
     if (config.deviceIpAddress)
         options.headers['X-PAYPAL-DEVICE-IPADDRESS'] = config.deviceIpAddress;
 
-    if (config.subject)
-        options.headers['X-PAYPAL-SECURITY-SUBJECT'] = config.subject;
-
     httpsPost(options, function (error, response) {
         if (error) { return callback(error); }
+
+        console.log("SDK OUTPUT");
+        console.log(response);
 
         var body = response.body;
         var statusCode = response.statusCode;
@@ -162,12 +158,26 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
 
         body.httpStatusCode = statusCode;
 
-        if (/^(Success|SuccessWithWarning)$/.test(body.responseEnvelope.ack)) {
-            callback(null, body);
-        } else {
-            var err = new Error('Response ack is ' + body.responseEnvelope.ack + '. Check the response for more info');
-            return callback(err, body);
+        console.log(body.error);
+
+        if(body.error){
+            var msg = "";
+
+            if(Array.isArray(body.error)){
+                
+                for(e of body.error){
+                    msg += e.message ? (e.message+". ") : "";
+                }
+            }
+            else
+                msg = "Unknown Error";
+
+            body.error.message = msg;
+
+            return callback(msg);
         }
+
+        callback(null, body);
     });
 };
 
@@ -236,14 +246,6 @@ Paypal.prototype.refund = function (params, callback) {
 adaptivePaymentsMethods.forEach(function (method) {
     var prototypeMethodName = method.charAt(0).toLowerCase() + method.slice(1);
     var apiMethodName = 'AdaptivePayments/' + method;
-    Paypal.prototype[prototypeMethodName] = function (data, callback) {
-        this.callApi(apiMethodName, data, callback);
-    };
-});
-
-adaptiveAccountsMethods.forEach(function (method) {
-    var prototypeMethodName = method.charAt(0).toLowerCase() + method.slice(1);
-    var apiMethodName = 'AdaptiveAccounts/' + method;
     Paypal.prototype[prototypeMethodName] = function (data, callback) {
         this.callApi(apiMethodName, data, callback);
     };

--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -114,8 +114,9 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
 
     var options = {
         hostname:   config.sandbox ? config.sandboxHostname : config.productionHostname,
-        path:       '/' + apiMethod,
-        data:       data,
+        port:  443,
+        path:  '/' + apiMethod,
+        data:  data,
         headers: {
             'X-PAYPAL-SECURITY-USERID':         config.userId,
             'X-PAYPAL-SECURITY-PASSWORD':       config.password,

--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -132,9 +132,6 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
     httpsPost(options, function (error, response) {
         if (error) { return callback(error); }
 
-        console.log("SDK OUTPUT");
-        console.log(response);
-
         var body = response.body;
         var statusCode = response.statusCode;
 
@@ -158,23 +155,27 @@ Paypal.prototype.callApi = function (apiMethod, data, callback) {
 
         body.httpStatusCode = statusCode;
 
-        console.log(body.error);
+        if(body.responseEnvelope.ack !== "Success" || body.responseEnvelope.ack !== "SuccessWithWarning"){
 
-        if(body.error){
-            var msg = "";
+            if(body.error){
+                var msg = "";
 
-            if(Array.isArray(body.error)){
-                
-                for(e of body.error){
-                    msg += e.message ? (e.message+". ") : "";
+                if(Array.isArray(body.error)){
+                    
+                    for(e of body.error){
+                        msg += e.message ? (e.message+". ") : "";
+                    }
                 }
+                else
+                    msg = "Unknown Error with Paypal Adaptive Payments";
+
+                body.error.message = msg;
+
+                return callback(msg);
             }
             else
-                msg = "Unknown Error";
+                return cb("Unknown Error with Paypal Adaptive Payments");
 
-            body.error.message = msg;
-
-            return callback(msg);
         }
 
         callback(null, body);


### PR DESCRIPTION
Hello,

This is resubmit of my previous pull request. Corrected those accidental deletes of the lines. 

Change Summary: 
- Added a logic to pass error message in the error object. If no error message were returned from Paypal for an error it will return generic error message (like it was already doing).
- Also removed a duplicate section at the bottom of the code, which was used to attach methods.
